### PR TITLE
Add property to be able to have three colors on the slider, one per each range

### DIFF
--- a/Demo/RangeSeekSliderDemo/Base.lproj/Main.storyboard
+++ b/Demo/RangeSeekSliderDemo/Base.lproj/Main.storyboard
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="12118" systemVersion="16E195" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="mFL-3X-bpM">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13771" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="mFL-3X-bpM">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12086"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13772"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -169,8 +170,32 @@
                                             <constraint firstAttribute="height" constant="65" id="wa9-1w-B3f"/>
                                         </constraints>
                                     </view>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Three colors" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ly1-8F-xBQ">
+                                        <rect key="frame" x="16" y="716" width="122" height="21"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="rsv-8r-dg6" customClass="RangeSeekSlider" customModule="RangeSeekSlider">
+                                        <rect key="frame" x="0.0" y="757" width="375" height="65"/>
+                                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="65" id="qCD-iE-y6O"/>
+                                        </constraints>
+                                        <userDefinedRuntimeAttributes>
+                                            <userDefinedRuntimeAttribute type="color" keyPath="colorLastRange">
+                                                <color key="value" red="1" green="0.25208848356750357" blue="0.1185216704788945" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                            </userDefinedRuntimeAttribute>
+                                            <userDefinedRuntimeAttribute type="color" keyPath="colorBetweenHandles">
+                                                <color key="value" red="0.20993182270138866" green="0.75902204949238583" blue="0.20433001812875645" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                            </userDefinedRuntimeAttribute>
+                                            <userDefinedRuntimeAttribute type="color" keyPath="initialColor">
+                                                <color key="value" red="0.63603773319229429" green="0.051143949552413158" blue="0.87716132614213194" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                            </userDefinedRuntimeAttribute>
+                                        </userDefinedRuntimeAttributes>
+                                    </view>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="By WorldDownTown" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="l8Q-0R-HSN">
-                                        <rect key="frame" x="230" y="716" width="128.5" height="17"/>
+                                        <rect key="frame" x="230.5" y="812" width="128" height="17"/>
                                         <fontDescription key="fontDescription" type="italicSystem" pointSize="14"/>
                                         <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <nil key="highlightedColor"/>
@@ -191,8 +216,11 @@
                                     <constraint firstAttribute="trailing" secondItem="Ziu-u7-MMb" secondAttribute="trailing" constant="16" id="IhU-gZ-Ury"/>
                                     <constraint firstItem="AzH-aT-IDj" firstAttribute="top" secondItem="aHO-Yd-TsS" secondAttribute="bottom" constant="20" id="Jm6-vy-cvb"/>
                                     <constraint firstItem="C9a-jS-yyk" firstAttribute="top" secondItem="wcl-zp-wAu" secondAttribute="top" constant="20" id="OPi-3h-sYH"/>
+                                    <constraint firstItem="Ly1-8F-xBQ" firstAttribute="top" secondItem="gdz-ut-dL8" secondAttribute="bottom" constant="20" id="PLF-FE-j7y"/>
                                     <constraint firstItem="gdz-ut-dL8" firstAttribute="top" secondItem="qwj-Dy-ogm" secondAttribute="bottom" constant="10" id="Rxx-Zc-1gn"/>
                                     <constraint firstItem="qwj-Dy-ogm" firstAttribute="leading" secondItem="wcl-zp-wAu" secondAttribute="leading" constant="16" id="S7C-ay-c6D"/>
+                                    <constraint firstItem="rsv-8r-dg6" firstAttribute="top" secondItem="Ly1-8F-xBQ" secondAttribute="bottom" constant="20" id="Soz-0l-fdQ"/>
+                                    <constraint firstItem="rsv-8r-dg6" firstAttribute="bottom" secondItem="l8Q-0R-HSN" secondAttribute="top" constant="10" id="TAD-Dd-A0z"/>
                                     <constraint firstItem="9hi-ch-oTe" firstAttribute="top" secondItem="oXk-Mj-BG8" secondAttribute="bottom" constant="10" id="Tzv-ph-4vH"/>
                                     <constraint firstItem="4K8-GF-10z" firstAttribute="leading" secondItem="wcl-zp-wAu" secondAttribute="leading" constant="16" id="VIk-99-ySf"/>
                                     <constraint firstItem="gdz-ut-dL8" firstAttribute="leading" secondItem="wcl-zp-wAu" secondAttribute="leading" constant="16" id="XEq-D5-ZxF"/>
@@ -210,7 +238,6 @@
                                     <constraint firstAttribute="trailing" secondItem="l8Q-0R-HSN" secondAttribute="trailing" constant="16" id="tDo-M2-uBo"/>
                                     <constraint firstItem="AzH-aT-IDj" firstAttribute="leading" secondItem="wcl-zp-wAu" secondAttribute="leading" constant="16" id="tFx-Hv-4vR"/>
                                     <constraint firstItem="qwj-Dy-ogm" firstAttribute="top" secondItem="9hi-ch-oTe" secondAttribute="bottom" constant="20" id="y1k-To-61Y"/>
-                                    <constraint firstItem="l8Q-0R-HSN" firstAttribute="top" secondItem="gdz-ut-dL8" secondAttribute="bottom" constant="20" id="zlo-Vh-ix6"/>
                                 </constraints>
                             </scrollView>
                         </subviews>
@@ -219,7 +246,11 @@
                             <constraint firstItem="wcl-zp-wAu" firstAttribute="leading" secondItem="dDy-w5-TsV" secondAttribute="leading" id="0sK-ah-MMg"/>
                             <constraint firstAttribute="bottom" secondItem="wcl-zp-wAu" secondAttribute="bottom" id="4S4-IF-MrC"/>
                             <constraint firstItem="wcl-zp-wAu" firstAttribute="top" secondItem="dDy-w5-TsV" secondAttribute="top" id="9Gl-VE-pgT"/>
+                            <constraint firstItem="rsv-8r-dg6" firstAttribute="width" secondItem="dDy-w5-TsV" secondAttribute="width" id="Giq-rK-ctr"/>
+                            <constraint firstAttribute="trailing" secondItem="Ly1-8F-xBQ" secondAttribute="trailing" constant="237" id="IhL-BA-ZJV"/>
                             <constraint firstAttribute="trailing" secondItem="wcl-zp-wAu" secondAttribute="trailing" id="WID-TM-WDl"/>
+                            <constraint firstItem="rsv-8r-dg6" firstAttribute="leading" secondItem="dDy-w5-TsV" secondAttribute="leading" id="mO0-uK-OJR"/>
+                            <constraint firstItem="Ly1-8F-xBQ" firstAttribute="leading" secondItem="dDy-w5-TsV" secondAttribute="leading" constant="16" id="rSM-M2-zZi"/>
                         </constraints>
                     </view>
                     <navigationItem key="navigationItem" title="RangeSeekSlider" id="BuP-se-RZI"/>
@@ -233,7 +264,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="YCF-VE-LZM" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1058" y="1050"/>
+            <point key="canvasLocation" x="1056.8" y="1049.3253373313344"/>
         </scene>
         <!--Navigation Controller-->
         <scene sceneID="Mel-0C-5NY">
@@ -241,7 +272,7 @@
                 <navigationController automaticallyAdjustsScrollViewInsets="NO" id="mFL-3X-bpM" sceneMemberID="viewController">
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="IJA-We-zv4">
-                        <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
+                        <rect key="frame" x="0.0" y="20" width="375" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <nil name="viewControllers"/>

--- a/Sources/RangeSeekSlider.swift
+++ b/Sources/RangeSeekSlider.swift
@@ -137,6 +137,9 @@ import UIKit
     /// Set slider line tint color between handles
     @IBInspectable open var colorBetweenHandles: UIColor?
 
+    /// Set slider line tint color for last range.
+    @IBInspectable open var colorLastRange: UIColor?
+
     /// The color of the entire slider when the handle is set to the minimum value and the maximum value. Default is nil.
     @IBInspectable open var initialColor: UIColor?
 
@@ -229,6 +232,7 @@ import UIKit
 
     private let sliderLine: CALayer = CALayer()
     private let sliderLineBetweenHandles: CALayer = CALayer()
+    private let sliderLineLastRange: CALayer = CALayer()
 
     private let leftHandle: CALayer = CALayer()
     private let rightHandle: CALayer = CALayer()
@@ -396,6 +400,8 @@ import UIKit
         // draw the track distline
         layer.addSublayer(sliderLineBetweenHandles)
 
+        layer.addSublayer(sliderLineLastRange)
+
         // draw the minimum slider handle
         leftHandle.cornerRadius = handleDiameter / 2.0
         leftHandle.borderWidth = handleBorderWidth
@@ -470,6 +476,7 @@ import UIKit
                                   height: lineHeight)
         sliderLine.cornerRadius = lineHeight / 2.0
         sliderLineBetweenHandles.cornerRadius = sliderLine.cornerRadius
+        sliderLineLastRange.cornerRadius = sliderLine.cornerRadius
     }
 
     private func updateLabelValues() {
@@ -502,6 +509,7 @@ import UIKit
         if let initialColor = initialColor?.cgColor, isInitial {
             minLabel.foregroundColor = initialColor
             maxLabel.foregroundColor = initialColor
+            sliderLineLastRange.backgroundColor = initialColor
             sliderLineBetweenHandles.backgroundColor = initialColor
             sliderLine.backgroundColor = initialColor
 
@@ -514,6 +522,7 @@ import UIKit
             let tintCGColor: CGColor = tintColor.cgColor
             minLabel.foregroundColor = minLabelColor?.cgColor ?? tintCGColor
             maxLabel.foregroundColor = maxLabelColor?.cgColor ?? tintCGColor
+            sliderLineLastRange.backgroundColor = colorLastRange?.cgColor ?? tintCGColor
             sliderLineBetweenHandles.backgroundColor = colorBetweenHandles?.cgColor ?? tintCGColor
             sliderLine.backgroundColor = tintCGColor
 
@@ -546,6 +555,11 @@ import UIKit
                                                 y: sliderLine.frame.minY,
                                                 width: rightHandle.position.x - leftHandle.position.x,
                                                 height: lineHeight)
+
+        sliderLineLastRange.frame = CGRect(x: rightHandle.position.x,
+                                           y: sliderLine.frame.minY,
+                                           width: sliderLine.frame.maxX - rightHandle.position.x,
+                                           height: lineHeight)
     }
 
     private func updateLabelPositions() {


### PR DESCRIPTION
We like to have three colours on the slider if required (one per each range), so a new property has been added: `colorLastRange`.

Setting up that property with a value, the slider will set up that color to its last section, from the right handler to the end.